### PR TITLE
fix(template): fixed executable formatting in template

### DIFF
--- a/src/Resources/skeleton/makefile/Makefile.tpl.php
+++ b/src/Resources/skeleton/makefile/Makefile.tpl.php
@@ -15,7 +15,7 @@
 <?= sprintf("%s: ## %s\n", $command->getName(), $command->getDescription()) ?>
 <?php foreach ($command->getInstructions() as $instruction): ?>
 <?php if (null !== $executable = $instruction->getExecutable()): ?>
-<?= sprintf("\t@$%s %s %s\n", mb_strtoupper($executable->getName()), $instruction->getName(), $instruction->formatArgumentsAndOptions()) ?>
+<?= sprintf("\t@$(%s) %s %s\n", mb_strtoupper($executable->getName()), $instruction->getName(), $instruction->formatArgumentsAndOptions()) ?>
 <?php else: ?>
 <?= sprintf("\t%s %s\n", $instruction->getName(), $instruction->formatArgumentsAndOptions()) ?>
 <?php endif ?>


### PR DESCRIPTION
Instructions with executable were rendering like:

```shell
hello: ## Say hello
	@$SYMFONY_CONSOLE app:hello John --last-name Doe
```

instead of

```shell
hello: ## Say hello
	@$(SYMFONY_CONSOLE) app:hello John --last-name Doe
```