### PR TITLE
[Executable] Removed yarn from built-in configuration

### DIFF
--- a/src/Resources/config/symandy_makefile_maker.xml
+++ b/src/Resources/config/symandy_makefile_maker.xml
@@ -8,7 +8,6 @@
     <symandy:config>
 
         <symandy:executable name="composer" />
-        <symandy:executable name="yarn"/>
 
         <symandy:group name="composer">
             <symandy:command name="composer-install" description="Install composer dependencies">


### PR DESCRIPTION
Yarn executable was removed from built-in configuration because Symfony recipes could not install the package on GitHub actions